### PR TITLE
First draft of the new CoC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Unacceptable behavior from any community member, including sponsors and those wi
 
 Anyone asked to stop unacceptable behavior is expected to comply immediately.
 
-If a community member engages in unacceptable behavior, official working group members may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event). Individuals who have been banned will be [blocked on GitHub](https://help.github.com/articles/blocking-a-user/) for the Hardware repo and prohibited from participating in any webcasts or other online or offline Node.js Hardware Working Group events.
+If a community member engages in unacceptable behavior, official working group members may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event). Individuals who have been banned will be prohibited from participating in GitHub discussions, issues, pull requests, any webcasts or other online or offline Node.js Hardware Working Group events.
 
 ### If You Witness or Are Subject to Unacceptable Behavior
 
@@ -58,9 +58,13 @@ If you feel you have been falsely or unfairly accused of violating this Code of 
 
 ### Contact Info
 
-If you need to report an incident, please email us at _insert email here_, or talk to any of the organizers at an event. In addition, you can contact any of the following official working group members directly:
+If you need to report an incident, please email us at [nodejshardware@theoreticalideations.com](mailto:nodejshardware@theoreticalideations.com), or talk to any of the organizers in the case of an in-person event. In addition, you may contact any of the following official working group members directly:
 
-_Insert people here_
+Chris Williams: voodootikigod@gmail.com
+
+Kassandra Perch: the@nodebotani.st
+
+Bryan Hughes: bryan@theoreticalideations.com
 
 ### Credit, License, and Attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+Contributing to the Node.js Hardware Working Group
+==================================================
+
+## Code of Conduct
+
+### Purpose
+
+The core of the NodeBots community is the people in it. Our primary goal is ensure this community is as inclusive to the largest number of people, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, gender identity and expression, sexual orientation, ability, physical appearance, body size, race, age, socioeconomic status, religion (or lack thereof), or other marginalized aspect of attendees.
+
+This code of conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
+
+We invite all those who participate in the Node.js Hardware Working Group to help us create safe and positive experiences for everyone.
+
+### Node.js Hardware Working Group Community Citizenship
+
+A supplemental goal of this Code of Conduct is to increase community citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.
+
+Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
+
+If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.
+
+### Expected Behavior
+
+* Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
+* Exercise consideration and respect in your speech and actions.
+* Don't make assumptions about a person's background, abilities, or intentions.
+* Attempt collaboration before conflict.
+* Refrain from demeaning, discriminatory, or harassing behavior and speech.
+* Be mindful of your surroundings and of your fellow participants. Alert an official working group member if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+
+### Unacceptable Behavior
+
+Unacceptable behaviors include: intimidating, harassing, abusive, discriminatory, derogatory or demeaning speech, actions, or microaggressions by any participant in our community on GitHub, related chat services, or other online spaces, in one-on-one communications carried out in the context of working group business, in person events, or at community related social events (such as a bar after an official event). Community event venues may be shared with members of the public; please be respectful to all patrons of these locations.
+
+Harassment includes: harmful or prejudicial verbal or written comments related to gender, sexual orientation, race, religion, disability; inappropriate use of nudity and/or sexual images in public spaces (including presentation slides); deliberate intimidation, stalking or following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact, and unwelcome sexual attention.
+
+Microaggressions are brief and commonplace daily verbal, behavioral, or environmental indignities, whether intentional or unintentional, that communicate hostile, derogatory, or negative racial or sexual slights and insults. We consider microaggressions to be a form of harassment, and we will take appropriate action for incidences of microagressions.
+
+### Consequences of Unacceptable Behavior
+
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a community member engages in unacceptable behavior, official working group members may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event). Individuals who have been banned will be [blocked on GitHub](https://help.github.com/articles/blocking-a-user/) for the Hardware repo and prohibited from participating in any webcasts or other online or offline Node.js Hardware Working Group events.
+
+### If You Witness or Are Subject to Unacceptable Behavior
+
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a working group member as soon as possible. Full contact information is listed in the Contact Info section of this document. All communications will be kept strictly confidential, unless otherwise required by law. No issue will be considered too inconsequential or unimportant.
+
+Additionally, official working group members are available to help community members engage with local law enforcement or to otherwise help those experiencing unacceptable behavior feel safe. In the context of in-person events, organizers will also provide escorts as desired by the person experiencing distress.
+
+### Governing Policy and Addressing Grievances
+
+If you receive a temporary or permanent ban, you will be [blocked on GitHub](https://help.github.com/articles/blocking-a-user/) for the Hardware repo and prohibited from participating in any webcasts or other online or offline Node.js Hardware Working Group events. If you receive a temporary ban, you will be notified via the email address listed on your GitHub profile, if listed, once the ban has been lifted and you are allowed to rejoin the community.
+
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify us with a concise description of your grievance at the email address listed under Contact Info. Your grievance will be handled in accordance with our governing policies.
+
+### Contact Info
+
+If you need to report an incident, please email us at _insert email here_, or talk to any of the organizers at an event. In addition, you can contact any of the following official working group members directly:
+
+_Insert people here_
+
+### Credit, License, and Attribution
+
+This Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/).
+
+This Code of Conduct is modified from the [NodeBots SF Code of Conduct](https://github.com/nodebots/sf/blob/master/coc.md). The structure and much of the content is sourced from the [Citizen Code of Conduct](http://citizencodeofconduct.org/). In addition, this document makes use of information fom [Geek Feminism](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), [Ashe Dryden](http://www.ashedryden.com/blog/codes-of-conduct-101-faq), and [Model View Culture](https://modelviewculture.com/issues/events).
+


### PR DESCRIPTION
In addition to anything else you see, please let me know your thoughts on the following:
- I use the term "official working group member" to indicate someone in a position of authority. I imagine that this will be people like @voodootikigod and anyone else listed as a member in the README for this repo. This is in contrast to the term "community member" which is basically everyone.
  - Is this confusing?
  - Should I add a "definitions" section or something to clarify?
- The contact information is currently blank.
  - Do we want to get some sort of hardware WG email address?
  - Should this forward to all "official working group members"? A subset/superset/some other set?
